### PR TITLE
imp(erc20): Disable erc20 callbacks denom route and multi-hop check

### DIFF
--- a/x/erc20/keeper/ibc_callbacks.go
+++ b/x/erc20/keeper/ibc_callbacks.go
@@ -108,12 +108,16 @@ func (k Keeper) OnRecvPacket(
 	pairID := k.GetTokenPairID(ctx, coin.Denom)
 	pair, found := k.GetTokenPair(ctx, pairID)
 	switch {
-	// Case 1. token pair is not registered and is a single hop IBC Coin
-	// by checking the prefix we ensure that only coins not native from this chain are evaluated.
-	// IsNativeFromSourceChain will check if the coin is native from the source chain.
-	// If the coin denom starts with `factory/` then it is a token factory coin, and we should not convert it
-	// NOTE: Check https://docs.osmosis.zone/osmosis-core/modules/tokenfactory/ for more information
-	case !found && strings.HasPrefix(coin.Denom, "ibc/") && ibc.IsBaseDenomFromSourceChain(data.Denom):
+	// // Case 1. token pair is not registered and is a single hop IBC Coin
+	// // by checking the prefix we ensure that only coins not native from this chain are evaluated.
+	// // IsNativeFromSourceChain will check if the coin is native from the source chain.
+	// // If the coin denom starts with `factory/` then it is a token factory coin, and we should not convert it
+	// // NOTE: Check https://docs.osmosis.zone/osmosis-core/modules/tokenfactory/ for more information
+	// case !found && strings.HasPrefix(coin.Denom, "ibc/"): && ibc.IsBaseDenomFromSourceChain(data.Denom):
+
+	// NOTE: for Saga we are allowing any valid IBC denomination to be auto-registered,
+	// be it native, factory or multi-hop coins.
+	case !found && strings.HasPrefix(coin.Denom, "ibc/"): //&& ibc.IsBaseDenomFromSourceChain(data.Denom):
 		tokenPair, err := k.RegisterERC20Extension(ctx, coin.Denom)
 		if err != nil {
 			return channeltypes.NewErrorAcknowledgement(err)


### PR DESCRIPTION
This PR disables the multi-hop and IBC route check for the ERC-20 IBC callbacks as it was done for the v19 release branch here: https://github.com/sagaxyz/evmos/commit/38f292eec45ee96122e4e246d147f10fd6dd069a