### PR TITLE
fix(tests): Fix EVM CanTransfer ante handler test

### DIFF
--- a/app/ante/evm/07_can_transfer_test.go
+++ b/app/ante/evm/07_can_transfer_test.go
@@ -87,6 +87,7 @@ func (suite *EvmAnteTestSuite) TestCanTransfer() {
 				unitNetwork.GetContext(),
 				unitNetwork.App.EvmKeeper,
 				coreMsg,
+				coreMsg.GasFeeCap(),
 				baseFeeResp.BaseFee.BigInt(),
 				ethCfg,
 				evmParams.Params,


### PR DESCRIPTION
This PR fixes the EVM ante handler test for the `CanTransfer` handler function.