### PR TITLE
chore: Rename erc20 denoms to use colon instead of slash

### DIFF
--- a/tests/nix_tests/test_erc20_ibc_callbacks.py
+++ b/tests/nix_tests/test_erc20_ibc_callbacks.py
@@ -112,7 +112,7 @@ def test_ibc_callbacks(
     assert erc20_balance == initial_amt
 
     # convert to IBC voucher
-    ibc_voucher_denom = f"erc20/{contract.address}"
+    ibc_voucher_denom = f"erc20:{contract.address}"
     if convert_amt > 0:
         rsp = evmos_cli.convert_erc20(contract.address, convert_amt, "signer2")
         assert rsp["code"] == 0, rsp["raw_log"]

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -146,7 +146,7 @@ func TestEvmosCoinDenom(t *testing.T) {
 		},
 		{
 			"valid denom - ethereum address (ERC-20 contract)",
-			"erc20/0x52908400098527886e0f7030069857D2E4169EE7",
+			"erc20:0x52908400098527886e0f7030069857D2E4169EE7",
 			false,
 		},
 		{

--- a/x/erc20/keeper/ibc_callbacks_test.go
+++ b/x/erc20/keeper/ibc_callbacks_test.go
@@ -30,7 +30,7 @@ import (
 	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
 )
 
-var erc20Denom = "erc20/0xdac17f958d2ee523a2206206994597c13d831ec7"
+var erc20Denom = "erc20:0xdac17f958d2ee523a2206206994597c13d831ec7"
 
 func (suite *KeeperTestSuite) TestOnRecvPacket() {
 	var ctx sdk.Context

--- a/x/erc20/keeper/ibc_callbacks_test.go
+++ b/x/erc20/keeper/ibc_callbacks_test.go
@@ -30,7 +30,7 @@ import (
 	evmtypes "github.com/evmos/evmos/v20/x/evm/types"
 )
 
-var erc20Denom = "erc20:0xdac17f958d2ee523a2206206994597c13d831ec7"
+var erc20Denom = types.CreateDenom("0xdac17f958d2ee523a2206206994597c13d831ec7")
 
 func (suite *KeeperTestSuite) TestOnRecvPacket() {
 	var ctx sdk.Context

--- a/x/erc20/keeper/integration_test.go
+++ b/x/erc20/keeper/integration_test.go
@@ -1,7 +1,6 @@
 package keeper_test
 
 import (
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -178,7 +177,7 @@ var _ = Describe("ERC20:", Ordered, func() {
 				})
 
 				It("should send coins to the receiver account", func() {
-					balRes, err := s.handler.GetBalanceFromBank(s.keyring.GetAccAddr(0), fmt.Sprintf("erc20/%s", contract.Hex()))
+					balRes, err := s.handler.GetBalanceFromBank(s.keyring.GetAccAddr(0), types.CreateDenom(contract.Hex()))
 					Expect(err).To(BeNil())
 					balanceCoin := balRes.Balance
 					Expect(balanceCoin.Amount).To(Equal(amt))

--- a/x/erc20/types/proposal.go
+++ b/x/erc20/types/proposal.go
@@ -20,6 +20,7 @@ const (
 	ProposalTypeRegisterCoin          string = "RegisterCoin"
 	ProposalTypeRegisterERC20         string = "RegisterERC20"
 	ProposalTypeToggleTokenConversion string = "ToggleTokenConversion" // #nosec
+	Erc20NativeCoinDenomPrefix        string = "erc20:"                // #nosec
 )
 
 // Implements Proposal Interface
@@ -42,19 +43,21 @@ func CreateDenomDescription(address string) string {
 
 // CreateDenom generates a string the module name plus the address to avoid conflicts with names staring with a number
 func CreateDenom(address string) string {
-	return fmt.Sprintf("%s/%s", ModuleName, address)
+	return Erc20NativeCoinDenomPrefix + address
 }
 
-// ValidateErc20Denom checks if a denom is a valid erc20/
-// denomination
+// ValidateErc20Denom checks if a denom is a valid erc20 denomination.
+// Only the "erc20:0xabc..." format is accepted.
 func ValidateErc20Denom(denom string) error {
-	denomSplit := strings.SplitN(denom, "/", 2)
-
-	if len(denomSplit) != 2 || denomSplit[0] != ModuleName {
-		return fmt.Errorf("invalid denom. %s denomination should be prefixed with the format 'erc20/", denom)
+	if strings.HasPrefix(denom, Erc20NativeCoinDenomPrefix) {
+		trimmed := strings.TrimPrefix(denom, Erc20NativeCoinDenomPrefix)
+		if len(trimmed) == 0 {
+			return fmt.Errorf("invalid denom (given: %s): missing address after prefix %s", denom, Erc20NativeCoinDenomPrefix)
+		}
+		return evmostypes.ValidateAddress(trimmed)
 	}
 
-	return evmostypes.ValidateAddress(denomSplit[1])
+	return fmt.Errorf("invalid denom (given: %s): denomination should be prefixed with %s", denom, Erc20NativeCoinDenomPrefix)
 }
 
 // NewRegisterERC20Proposal returns new instance of RegisterERC20Proposal

--- a/x/erc20/types/proposal_test.go
+++ b/x/erc20/types/proposal_test.go
@@ -59,12 +59,12 @@ func (suite *ProposalTestSuite) TestCreateDenom() {
 		{
 			"with valid address",
 			"0xdac17f958d2ee523a2206206994597c13d831ec7",
-			"erc20/0xdac17f958d2ee523a2206206994597c13d831ec7",
+			"erc20:0xdac17f958d2ee523a2206206994597c13d831ec7",
 		},
 		{
 			"with empty string",
 			"",
-			"erc20/",
+			"erc20:",
 		},
 	}
 	for _, tc := range testCases {
@@ -80,28 +80,38 @@ func (suite *ProposalTestSuite) TestValidateErc20Denom() {
 		expPass bool
 	}{
 		{
-			"- instead of /",
+			"fail: invalid address",
+			"0xdac17f958d2ee523a22",
+			false,
+		},
+		{
+			"fail: doesn't start with erc20:",
+			"0xdac17f958d2ee523a2206206994597c13d831ec7",
+			false,
+		},
+		{
+			"- instead of :",
 			"erc20-0xdac17f958d2ee523a2206206994597c13d831ec7",
 			false,
 		},
 		{
-			"without /",
+			"without :",
 			"conversionCoin",
 			false,
 		},
 		{
-			"// instead of /",
-			"erc20//0xdac17f958d2ee523a2206206994597c13d831ec7",
+			"fail: :: instead of :",
+			"erc20::0xdac17f958d2ee523a2206206994597c13d831ec7",
 			false,
 		},
 		{
-			"multiple /",
-			"erc20/0xdac17f958d2ee523a2206206994597c13d831ec7/test",
+			"multiple :",
+			"erc20:0xdac17f958d2ee523a2206206994597c13d831ec7:test",
 			false,
 		},
 		{
 			"pass",
-			"erc20/0xdac17f958d2ee523a2206206994597c13d831ec7",
+			"erc20:0xdac17f958d2ee523a2206206994597c13d831ec7",
 			true,
 		},
 	}

--- a/x/erc20/types/proposal_test.go
+++ b/x/erc20/types/proposal_test.go
@@ -59,7 +59,7 @@ func (suite *ProposalTestSuite) TestCreateDenom() {
 		{
 			"with valid address",
 			"0xdac17f958d2ee523a2206206994597c13d831ec7",
-			"erc20:0xdac17f958d2ee523a2206206994597c13d831ec7",
+			types.CreateDenom("0xdac17f958d2ee523a2206206994597c13d831ec7"),
 		},
 		{
 			"with empty string",
@@ -111,7 +111,7 @@ func (suite *ProposalTestSuite) TestValidateErc20Denom() {
 		},
 		{
 			"pass",
-			"erc20:0xdac17f958d2ee523a2206206994597c13d831ec7",
+			types.CreateDenom("0xdac17f958d2ee523a2206206994597c13d831ec7"),
 			true,
 		},
 	}

--- a/x/erc20/types/utils.go
+++ b/x/erc20/types/utils.go
@@ -18,7 +18,7 @@ const (
 	reLeadingNumbers = `(?m)^(\d+)`
 	// ^[^A-Za-z] forces first chars to be letters
 	// [^a-zA-Z0-9/-] deletes special characters
-	reDnmString = `^[^A-Za-z]|[^a-zA-Z0-9/-]`
+	reDnmString = `^[^A-Za-z]|[^a-zA-Z0-9/:-]`
 )
 
 func removeLeadingNumbers(str string) string {
@@ -46,7 +46,7 @@ func removeInvalidPrefixes(str string) string {
 }
 
 // SanitizeERC20Name enforces 128 max string length, deletes leading numbers
-// removes special characters  (except /)  and spaces from the ERC20 name
+// removes special characters  (except / and :)  and spaces from the ERC20 name
 func SanitizeERC20Name(name string) string {
 	name = removeLeadingNumbers(name)
 	name = removeSpecialChars(name)

--- a/x/erc20/types/utils.go
+++ b/x/erc20/types/utils.go
@@ -39,6 +39,9 @@ func removeInvalidPrefixes(str string) string {
 	if strings.HasPrefix(str, "erc20/") {
 		return removeInvalidPrefixes(str[6:])
 	}
+	if strings.HasPrefix(str, "erc20:") {
+		return removeInvalidPrefixes(str[6:])
+	}
 	return str
 }
 

--- a/x/erc20/types/utils_test.go
+++ b/x/erc20/types/utils_test.go
@@ -33,6 +33,7 @@ func TestSanitizeERC20Name(t *testing.T) {
 		{"name contains '/'", "ibc/erc20/ibc/20invalid", "20invalid", false},
 		{"name contains '/'", "123/leadingslash", "leadingslash", true},
 		{"name contains '-'", "Dash-Coin", "Dash-Coin", true},
+		{"name contains ':'", "erc20:valid", "valid", true},
 		{"really long word", strings.Repeat("a", 150), strings.Repeat("a", 128), true},
 		{"single word name: Token", "Token", "Token", true},
 		{"single word name: Coin", "Coin", "Coin", true},

--- a/x/ibc/transfer/keeper/msg_server_test.go
+++ b/x/ibc/transfer/keeper/msg_server_test.go
@@ -6,13 +6,13 @@ import (
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
 	"github.com/evmos/evmos/v20/testutil/integration/evmos/keyring"
 	testutils "github.com/evmos/evmos/v20/testutil/integration/evmos/utils"
+	erc20types "github.com/evmos/evmos/v20/x/erc20/types"
 	"github.com/evmos/evmos/v20/x/ibc/transfer/keeper"
 	"github.com/stretchr/testify/mock"
 )
@@ -49,7 +49,7 @@ func (suite *KeeperTestSuite) TestTransfer() {
 				contractAddr, err := suite.DeployContract("coin", "token", uint8(6))
 				suite.Require().NoError(err)
 
-				transferMsg := types.NewMsgTransfer("transfer", "channel-0", sdk.NewCoin("erc20/"+contractAddr.String(), math.NewInt(10)), addr, "", timeoutHeight, 0, "")
+				transferMsg := types.NewMsgTransfer("transfer", "channel-0", sdk.NewCoin(erc20types.CreateDenom(contractAddr.String()), math.NewInt(10)), addr, "", timeoutHeight, 0, "")
 				return transferMsg
 			},
 			false,
@@ -180,7 +180,7 @@ func (suite *KeeperTestSuite) TestTransfer() {
 				suite.Require().NoError(err)
 				suite.Require().True(len(res) == 1)
 				pair := res[0]
-				suite.Require().Equal("erc20/"+pair.Erc20Address, pair.Denom)
+				suite.Require().Equal(erc20types.CreateDenom(pair.Erc20Address), pair.Denom)
 
 				amt := math.NewInt(10)
 				_, err = suite.MintERC20Token(contractAddr, sender.Addr, amt.BigInt())


### PR DESCRIPTION
This PR mirrors the changes that have been introduced in the Cosmos EVM on PR [#92](https://github.com/cosmos/evm/pull/92), which renames the `erc20/` prefix to `erc20:`.

The motivation for this change is laid out in https://github.com/cosmos/evm/issues/61.
In short - the current IBC v2 does not allow for `/` in denominations, which may possibly change going forward, but at least currently is the case.