### PR TITLE
fix: Revert MaxPrecompileCalls to 100

### DIFF
--- a/x/evm/types/call.go
+++ b/x/evm/types/call.go
@@ -14,4 +14,4 @@ const (
 // MaxPrecompileCalls is the maximum number of precompile
 // calls within a transaction. We want to limit this because
 // for each precompile tx we're creating a cached context
-const MaxPrecompileCalls uint8 = 7
+const MaxPrecompileCalls uint8 = 100


### PR DESCRIPTION
# Description

Reverting MaxPrecompileCalls to 100 to avoid reverted executions during queries. All credit to @luckychess 🏆 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

<!-- Please keep your PR as draft until it's ready for review -->

<!-- Pull requests that sit inactive for longer than 30 days will be closed.  -->

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member
- [ ] left instructions on how to review the changes
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/evmos/evmos/blob/main/CONTRIBUTING.md#pr-targeting))

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed
